### PR TITLE
Updates

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -34,3 +34,8 @@ export let mountEditor = (root, readOnly = false) =>
     minimap: { enabled: false },
     scrollBeyondLastLine: false,
   })
+
+/**
+ * @param {'vs' | 'vs-dark'} theme
+ */
+export const setTheme = (theme) => monaco.editor.setTheme(theme)

--- a/index.html
+++ b/index.html
@@ -8,9 +8,40 @@
       href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>✌️</text></svg>"
     />
   </head>
+  <script type="application/javascript">
+    const savedPreference = localStorage.getItem('dark')
+    const browserPreference = window.matchMedia(
+      '(prefers-color-scheme: dark)'
+    ).matches
+    if (
+      (savedPreference && savedPreference === '1') ||
+      (!savedPreference && browserPreference)
+    )
+      document.documentElement.classList.add('dark')
+  </script>
   <style>
+    :root {
+      --header-height: calc(1.5rem + 2px);
+      --background-color: #fffffe;
+      --foreground-color: #1e1e1e;
+      --header-border-color: #ccc;
+    }
+
+    html.dark {
+      --background-color: #1e1e1e;
+      --foreground-color: #fffffe;
+      --header-border-color: #555;
+    }
+
     main {
       display: flex;
+    }
+
+    html {
+      background-color: var(--background-color);
+      color: var(--foreground-color);
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+      -webkit-font-smoothing: antialiased;
     }
 
     html,
@@ -22,16 +53,37 @@
       margin: 0;
     }
 
-    #src,
-    #result {
+    header {
+      height: var(--header-height);
+      border-bottom: 2px solid var(--header-border-color);
+      padding: 0 0.5rem;
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+    }
+
+    .darkModeLabel {
+      user-select: none;
+    }
+
+    .editor {
+      height: calc(100% - var(--header-height));
       flex: 1 0 50%;
     }
   </style>
   <script type="module" src="./index.ts"></script>
   <body>
+    <header>
+      <form>
+        <label class="darkModeLabel">
+          <input type="checkbox" id="darkToggle" />
+          Dark
+        </label>
+      </form>
+    </header>
     <main>
-      <div id="src"></div>
-      <div id="result"></div>
+      <div id="src" class="editor"></div>
+      <div id="result" class="editor"></div>
     </main>
   </body>
 </html>

--- a/index.ts
+++ b/index.ts
@@ -51,7 +51,7 @@ export default class ProgressBar extends Vue {
     })
   }
 
-  classMethod(): number {
-    return 4
+  classMethod(input: number): number {
+    return input * 4
   }
 }`)

--- a/index.ts
+++ b/index.ts
@@ -73,6 +73,6 @@ export default class ProgressBar extends Vue {
   }
 
   classMethod(input: number): number {
-    return input * 4
+    return this.compute * input * 4
   }
 }`)

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import { mountEditor } from './editor'
+import { mountEditor, setTheme } from './editor'
 
 let srcEditor = mountEditor('#src')
 let resultEditor = mountEditor('#result', true)
@@ -6,6 +6,22 @@ let resultEditor = mountEditor('#result', true)
 let transformWorker = new Worker(new URL('./worker.ts', import.meta.url), {
   type: 'module',
 })
+
+const darkToggle = document.querySelector('#darkToggle') as HTMLInputElement
+const savedPreference = localStorage.getItem('dark')
+const browserPreference = window.matchMedia(
+  '(prefers-color-scheme: dark)'
+).matches
+function updateTheme(dark: boolean) {
+  localStorage.setItem('dark', dark ? '1' : '0')
+  setTheme(dark ? 'vs-dark' : 'vs')
+  darkToggle.checked = dark
+  document.documentElement.classList[dark ? 'add' : 'remove']('dark')
+}
+updateTheme(savedPreference ? savedPreference === '1' : browserPreference)
+darkToggle?.addEventListener('change', (event) =>
+  updateTheme((event.target as HTMLInputElement).checked)
+)
 
 srcEditor
   .getModel()

--- a/index.ts
+++ b/index.ts
@@ -33,8 +33,13 @@ export default class ProgressBar extends Vue {
   
   data1: IData | null = null
   data2 = 123
+
+  @Watch('watchedProperty')
+  runEffect() {
+    window.alert('changed')
+  }
   
-  get compute() {
+  get compute(): string {
     return this.id.toString()
   }
   
@@ -44,5 +49,9 @@ export default class ProgressBar extends Vue {
     this.$nextTick(() => {
       this.$emit('event', someStore.price)
     })
+  }
+
+  classMethod(): number {
+    return 4
   }
 }`)

--- a/index.ts
+++ b/index.ts
@@ -38,6 +38,11 @@ export default class ProgressBar extends Vue {
   runEffect() {
     window.alert('changed')
   }
+
+  @Watch('otherWatchedProperty', { immediate: true })
+  runAnotherEffect() {
+    window.alert('other thing changed')
+  }
   
   get compute(): string {
     return this.id.toString()

--- a/transformer.ts
+++ b/transformer.ts
@@ -154,6 +154,8 @@ const transformer = (src: string, j: JSCodeshift) => {
           } else if (propName === 'beforeDestroy') {
             toImportFromComposition.add('onBeforeUnmount')
             hooks.push(statement`onBeforeUnmount(() => ${classMethod.body});`)
+          } else if (propName === 'created') {
+            hooks.push(...classMethod.body.body.map((st) => statement`${st}`))
           } else {
             const fn = j.functionDeclaration(
               j.identifier(propName),

--- a/transformer.ts
+++ b/transformer.ts
@@ -249,7 +249,7 @@ const transformer = (src: string, j: JSCodeshift) => {
         [...toImportFromComposition]
           .sort()
           .map((n) => j.importSpecifier(j.identifier(n))),
-        str('@vue/composition-api')
+        str('vue')
       )
     )
 

--- a/transformer.ts
+++ b/transformer.ts
@@ -118,20 +118,14 @@ const transformer = (src: string, j: JSCodeshift) => {
         // getter
         if (classMethod.kind === 'get') {
           toImportFromComposition.add('computed')
-          const type = classMethod.returnType?.typeAnnotation
-          if (type) {
-            computed.push(
-              statement`const ${propName} = computed<${type}>(() => ${classMethod.body});`
-            )
-          } else {
-            computed.push(
-              statement`const ${propName} = computed(() => ${classMethod.body});`
-            )
-          }
+          computed.push(
+            statement`const ${propName} = computed(() => ${classMethod.body});`
+          )
         } else if (
           watchDecorator &&
           j.CallExpression.check(watchDecorator.expression)
         ) {
+          toImportFromComposition.add('watch')
           const watcherArgs = watchDecorator.expression.arguments
           const watchedExpression =
             watcherArgs?.[0].type === 'StringLiteral' && watcherArgs[0].value

--- a/transformer.ts
+++ b/transformer.ts
@@ -126,13 +126,13 @@ const transformer = (src: string, j: JSCodeshift) => {
             toImportFromComposition.add('onBeforeUnmount')
             hooks.push(statement`onBeforeUnmount(() => ${classMethod.body});`)
           } else {
-            functions.push(
-              j.functionDeclaration(
-                j.identifier(propName),
-                classMethod.params,
-                classMethod.body
-              )
+            const fn = j.functionDeclaration(
+              j.identifier(propName),
+              classMethod.params,
+              classMethod.body
             )
+            fn.returnType = classMethod.returnType
+            functions.push(fn)
           }
         }
       } else {


### PR DESCRIPTION
- Change import from `@vue/composition-api` to `vue` to match 2.7. Maybe this could to be configurable?
- Added support for watchers
- Exposed refs in the return statement
- Excluded lifecycle methods from the return statement
- Preserve return types on computed and methods
- Add dark mode